### PR TITLE
Feature/add auth config

### DIFF
--- a/src/taipy/config/__init__.py
+++ b/src/taipy/config/__init__.py
@@ -14,6 +14,7 @@ from .checker.issue_collector import IssueCollector
 from .config import Config
 from .data_node.data_node_config import DataNodeConfig
 from .global_app.global_app_config import GlobalAppConfig
+from .auth.auth_config import AuthConfig
 from .job_execution.job_config import JobConfig
 from .pipeline.pipeline_config import PipelineConfig
 from .scenario.scenario_config import ScenarioConfig

--- a/src/taipy/config/_config.py
+++ b/src/taipy/config/_config.py
@@ -12,6 +12,7 @@
 from copy import copy
 from typing import Dict
 
+from .auth.auth_config import AuthConfig
 from .data_node.data_node_config import DataNodeConfig
 from .global_app.global_app_config import GlobalAppConfig
 from .job_execution.job_config import JobConfig
@@ -25,6 +26,7 @@ class _Config:
 
     def __init__(self):
         self._global_config: GlobalAppConfig = GlobalAppConfig()
+        self._auth_config: AuthConfig = AuthConfig()
         self._job_config: JobConfig = JobConfig()
         self._data_nodes: Dict[str, DataNodeConfig] = {}
         self._tasks: Dict[str, TaskConfig] = {}
@@ -35,6 +37,7 @@ class _Config:
     def _default_config(cls):
         config = _Config()
         config._global_config = GlobalAppConfig.default_config()
+        config._auth_config = AuthConfig.default_config()
         config._job_config = JobConfig().default_config()
         config._data_nodes = {cls.DEFAULT_KEY: DataNodeConfig.default_config(cls.DEFAULT_KEY)}
         config._tasks = {cls.DEFAULT_KEY: TaskConfig.default_config(cls.DEFAULT_KEY)}
@@ -44,6 +47,7 @@ class _Config:
 
     def _update(self, other_config):
         self._global_config._update(other_config._global_config._to_dict())
+        self._auth_config._update(other_config._auth_config._to_dict())
         self._job_config._update(other_config._job_config._to_dict())
         self.__update_entity_configs(self._data_nodes, other_config._data_nodes, DataNodeConfig)
         self.__update_entity_configs(self._tasks, other_config._tasks, TaskConfig)

--- a/src/taipy/config/auth/__init__.py
+++ b/src/taipy/config/auth/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2022 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.

--- a/src/taipy/config/auth/auth_config.py
+++ b/src/taipy/config/auth/auth_config.py
@@ -1,0 +1,86 @@
+# Copyright 2022 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from copy import copy
+from typing import Any, Dict, Optional
+from ..common._template_handler import _TemplateHandler as _tpl
+
+
+class AuthConfig:
+    """
+    Configuration fields needed to use authentication feature.
+
+    Attributes:
+        protocol (str):  identifier of the authentication protocol. Taipy already implements three predefined
+            protocols:
+                - None: ...
+                - taipy: ...
+                - ldap: ...
+        **properties: A dictionary of additional properties.
+    """
+
+    _PROTOCOL_KEY = "protocol"
+
+    _PROTOCOL_LDAP = "ldap"
+    _LDAP_SERVER = "ldap_server"
+    _LDAP_BASE_DN = "ldap_base_dn"
+
+    _PROTOCOL_TAIPY = "taipy"
+    _TAIPY_ROLES = "roles"
+    _TAIPY_PWD = "passwords"
+
+    def __init__(self, protocol: str = None, **properties):
+        self._protocol = protocol
+        self._properties = properties
+
+    def __getattr__(self, item: str) -> Optional[Any]:
+        return _tpl._replace_templates(self._properties.get(item))
+
+    def __copy__(self):
+        return AuthConfig(self._protocol, **copy(self._properties))
+
+    @property
+    def protocol(self):
+        return _tpl._replace_templates(self._protocol)
+
+    @protocol.setter  # type: ignore
+    def protocol(self, val):
+        self._protocol = val
+
+    @property
+    def properties(self):
+        return {k: _tpl._replace_templates(v) for k, v in self._properties.items()}
+
+    @properties.setter  # type: ignore
+    def properties(self, val):
+        self._properties = val
+
+    @classmethod
+    def default_config(cls):
+        return AuthConfig()
+
+    def _to_dict(self):
+        as_dict = {}
+        if self._protocol is not None:
+            as_dict[self._PROTOCOL_KEY] = self._protocol
+        as_dict.update(self._properties)
+        return as_dict
+
+    @classmethod
+    def _from_dict(cls, config_as_dict: Dict[str, Any]):
+        config = AuthConfig()
+        config._protocol = config_as_dict.pop(cls._PROTOCOL_KEY, None)
+        config._properties = config_as_dict
+        return config
+
+    def _update(self, config_as_dict):
+        self._protocol = config_as_dict.pop(self._PROTOCOL_KEY, self._protocol)
+        self._properties.update(config_as_dict)

--- a/src/taipy/config/checker/_checkers/_auth_config_checker.py
+++ b/src/taipy/config/checker/_checkers/_auth_config_checker.py
@@ -1,0 +1,61 @@
+# Copyright 2022 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from ._config_checker import _ConfigChecker
+from ..issue_collector import IssueCollector
+from ..._config import _Config
+from ...auth.auth_config import AuthConfig
+
+
+class _AuthConfigChecker(_ConfigChecker):
+    def __init__(self, config: _Config, collector: IssueCollector):
+        super().__init__(config, collector)
+
+    def _check(self) -> IssueCollector:
+        auth_config = self._config._auth_config
+        self._check_predefined_protocol(auth_config)
+        return self._collector
+
+    def _check_predefined_protocol(self, auth_config: AuthConfig):
+        if auth_config.protocol == auth_config._PROTOCOL_LDAP:
+            self.__check_ldap(auth_config)
+        if auth_config.protocol == auth_config._PROTOCOL_TAIPY:
+            self.__check_taipy(auth_config)
+
+    def __check_taipy(self, auth_config):
+        if auth_config._TAIPY_ROLES not in auth_config.properties:
+            self._error(
+                "properties",
+                auth_config._LDAP_SERVER,
+                f"`{auth_config._LDAP_SERVER}` property must be populated when {auth_config._PROTOCOL_LDAP} is used."
+            )
+        if auth_config._TAIPY_PWD not in auth_config.properties:
+            self._warning(
+                "properties",
+                auth_config._TAIPY_PWD,
+                f"`In order to protect authentication with passwords using {auth_config._PROTOCOL_TAIPY} protocol,"
+                f" {auth_config._TAIPY_PWD}` property can be populated."
+            )
+
+    def __check_ldap(self, auth_config):
+        if auth_config._LDAP_SERVER not in auth_config.properties:
+            self._error(
+                "properties",
+                auth_config._LDAP_SERVER,
+                f"`{auth_config._LDAP_SERVER}` attribute must be populated when {auth_config._PROTOCOL_LDAP} is used."
+            )
+        if auth_config._LDAP_BASE_DN not in auth_config.properties:
+            self._error(
+                "properties",
+                auth_config._LDAP_BASE_DN,
+                f"`{auth_config._LDAP_BASE_DN}` field must be populated when {auth_config._PROTOCOL_LDAP} is used."
+            )
+

--- a/src/taipy/config/config.py
+++ b/src/taipy/config/config.py
@@ -12,6 +12,7 @@
 import os
 from typing import Any, Callable, Dict, List, Optional, Union
 
+from .auth.auth_config import AuthConfig
 from .common._classproperty import _Classproperty
 from ..logger._taipy_logger import _TaipyLogger
 from .scenario.frequency import Frequency
@@ -39,6 +40,11 @@ class Config:
     _env_file_config = None
     _applied_config = _Config._default_config()
     _collector = IssueCollector()
+
+    @_Classproperty
+    def auth(cls) -> AuthConfig:
+        """Return configuration values related to the authentication as a `AuthConfig^`."""
+        return cls._applied_config._job_config
 
     @_Classproperty
     def job_config(cls) -> JobConfig:
@@ -102,6 +108,16 @@ class Config:
     @classmethod
     def _export_code_config(cls, filename):
         _TomlSerializer()._write(cls._python_config, filename)
+
+    @classmethod
+    def configure_auth(
+        cls,
+        protocol: str = None,
+        **properties,
+    ) -> AuthConfig:
+        cls._python_config._auth_config = AuthConfig(protocol, **properties)
+        cls.__compile_configs()
+        return cls._applied_config._auth_config
 
     @classmethod
     def configure_global_app(

--- a/src/taipy/config/config.py
+++ b/src/taipy/config/config.py
@@ -115,6 +115,18 @@ class Config:
         protocol: str = None,
         **properties,
     ) -> AuthConfig:
+        """Configure authentication.
+
+        Parameters:
+            protocol (Optional[str]): protocol (str):  identifier of the authentication protocol. Taipy already
+                implements three predefined protocols:
+                    - None: ...
+                    - taipy: ...
+                    - ldap: ...
+            **properties: A dictionary of additional properties.
+        Returns:
+            AuthConfig^: The auth configuration.
+        """
         cls._python_config._auth_config = AuthConfig(protocol, **properties)
         cls.__compile_configs()
         return cls._applied_config._auth_config


### PR DESCRIPTION
I created a dedicated block in the config for the auth.
So instead of reading attributes from `Config.global_config`, we can use `Config.auth` 

REMAINING TODO: 
- Unit tests
- Documentation
- Release notes