### PR TITLE
Add support for timedelta in serializers

### DIFF
--- a/src/taipy/config/_base_serializer.py
+++ b/src/taipy/config/_base_serializer.py
@@ -27,16 +27,6 @@ from .global_app.global_app_config import GlobalAppConfig
 from .unique_section import UniqueSection
 
 
-def _timedelta_to_str(obj: timedelta) -> str:
-    total_seconds = obj.total_seconds()
-    return (
-        f"{int(total_seconds // 86400)}d"
-        f"{int(total_seconds % 86400 // 3600)}h"
-        f"{int(total_seconds % 3600 // 60)}m"
-        f"{int(total_seconds % 60)}s"
-    )
-
-
 class _BaseSerializer(object):
     """Base serializer class for taipy configuration."""
 
@@ -80,7 +70,7 @@ class _BaseSerializer(object):
         if isinstance(as_dict, datetime):
             return as_dict.isoformat() + ":datetime"
         if isinstance(as_dict, timedelta):
-            return _timedelta_to_str(as_dict) + ":timedelta"
+            return cls._timedelta_to_str(as_dict) + ":timedelta"
         if inspect.isfunction(as_dict) or isinstance(as_dict, types.BuiltinFunctionType):
             return as_dict.__module__ + "." + as_dict.__name__ + ":function"
         if inspect.isclass(as_dict):
@@ -154,3 +144,13 @@ class _BaseSerializer(object):
             if isinstance(val, list):
                 return [cls._pythonify(v) for v in val]
         return val
+
+    @classmethod
+    def _timedelta_to_str(cls, obj: timedelta) -> str:
+        total_seconds = obj.total_seconds()
+        return (
+            f"{int(total_seconds // 86400)}d"
+            f"{int(total_seconds % 86400 // 3600)}h"
+            f"{int(total_seconds % 3600 // 60)}m"
+            f"{int(total_seconds % 60)}s"
+        )

--- a/src/taipy/config/_base_serializer.py
+++ b/src/taipy/config/_base_serializer.py
@@ -99,7 +99,9 @@ class _BaseSerializer(object):
         for section_name, sect_as_dict in as_dict.items():
             if section_class := cls._section_class.get(section_name, None):
                 if issubclass(section_class, UniqueSection):
-                    config._unique_sections[section_name] = section_class._from_dict(sect_as_dict, None, None)  # type: ignore
+                    config._unique_sections[section_name] = section_class._from_dict(
+                        sect_as_dict, None, None
+                    )  # type: ignore
                 elif issubclass(section_class, Section):
                     config._sections[section_name] = cls._extract_node(as_dict, section_class, section_name, config)
         return config
@@ -109,7 +111,10 @@ class _BaseSerializer(object):
         match = re.fullmatch(_TemplateHandler._PATTERN, str(val))
         if not match:
             if isinstance(val, str):
-                TYPE_PATTERN = r"^(.+):(\bbool\b|\bstr\b|\bint\b|\bfloat\b|\bdatetime\b||\btimedelta\b|\bfunction\b|\bclass\b|\bSCOPE\b|\bFREQUENCY\b|\bSECTION\b)?$"
+                TYPE_PATTERN = (
+                    r"^(.+):(\bbool\b|\bstr\b|\bint\b|\bfloat\b|\bdatetime\b||\btimedelta\b|"
+                    r"\bfunction\b|\bclass\b|\bSCOPE\b|\bFREQUENCY\b|\bSECTION\b)?$"
+                )
                 match = re.fullmatch(TYPE_PATTERN, str(val))
                 if match:
                     actual_val = match.group(1)

--- a/src/taipy/config/_json_serializer.py
+++ b/src/taipy/config/_json_serializer.py
@@ -10,11 +10,8 @@
 # specific language governing permissions and limitations under the License.
 
 import json  # type: ignore
-from datetime import datetime, timedelta
-from enum import Enum
-from typing import Any
 
-from ._base_serializer import _BaseSerializer, _timedelta_to_str
+from ._base_serializer import _BaseSerializer
 from ._config import _Config
 from .exceptions.exceptions import LoadingError
 
@@ -25,9 +22,7 @@ class _JsonSerializer(_BaseSerializer):
     @classmethod
     def _write(cls, configuration: _Config, filename: str):
         with open(filename, "w") as fd:
-            json.dump(
-                cls._str(configuration), fd, ensure_ascii=False, indent=0, check_circular=False, cls=_CustomEncoder
-            )
+            json.dump(cls._str(configuration), fd, ensure_ascii=False, indent=0, check_circular=False)
 
     @classmethod
     def _read(cls, filename: str) -> _Config:
@@ -41,27 +36,8 @@ class _JsonSerializer(_BaseSerializer):
 
     @classmethod
     def _serialize(cls, configuration: _Config) -> str:
-        return json.dumps(
-            cls._str(configuration), ensure_ascii=False, indent=0, check_circular=False, cls=_CustomEncoder
-        )
+        return json.dumps(cls._str(configuration), ensure_ascii=False, indent=0, check_circular=False)
 
     @classmethod
     def _deserialize(cls, config_as_string: str) -> _Config:
         return cls._from_dict(cls._pythonify(dict(json.loads(config_as_string))))
-
-
-class Json:
-    pass
-
-
-class _CustomEncoder(json.JSONEncoder):
-    def default(self, o: Any) -> Json:
-        if isinstance(o, Enum):
-            result = o.value
-        elif isinstance(o, datetime):
-            result = f"{o.isoformat()}:datetime"
-        elif isinstance(o, timedelta):
-            result = f"{_timedelta_to_str(o)}:timedelta"
-        else:
-            result = json.JSONEncoder.default(self, o)
-        return result

--- a/src/taipy/config/checker/__init__.py
+++ b/src/taipy/config/checker/__init__.py
@@ -8,4 +8,3 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
-

--- a/src/taipy/config/checker/_checkers/__init__.py
+++ b/src/taipy/config/checker/_checkers/__init__.py
@@ -8,4 +8,3 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
-

--- a/src/taipy/config/checker/_checkers/_auth_config_checker.py
+++ b/src/taipy/config/checker/_checkers/_auth_config_checker.py
@@ -9,9 +9,9 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from ._config_checker import _ConfigChecker
-from ..issue_collector import IssueCollector
 from ..._config import _Config
+from ..issue_collector import IssueCollector
+from ._config_checker import _ConfigChecker
 
 
 class _AuthConfigChecker(_ConfigChecker):
@@ -34,14 +34,14 @@ class _AuthConfigChecker(_ConfigChecker):
             self._error(
                 "properties",
                 auth_config._LDAP_SERVER,
-                f"`{auth_config._LDAP_SERVER}` property must be populated when {auth_config._PROTOCOL_LDAP} is used."
+                f"`{auth_config._LDAP_SERVER}` property must be populated when {auth_config._PROTOCOL_LDAP} is used.",
             )
         if auth_config._TAIPY_PWD not in auth_config.properties:
             self._warning(
                 "properties",
                 auth_config._TAIPY_PWD,
                 f"`In order to protect authentication with passwords using {auth_config._PROTOCOL_TAIPY} protocol,"
-                f" {auth_config._TAIPY_PWD}` property can be populated."
+                f" {auth_config._TAIPY_PWD}` property can be populated.",
             )
 
     def __check_ldap(self, auth_config):
@@ -49,12 +49,11 @@ class _AuthConfigChecker(_ConfigChecker):
             self._error(
                 "properties",
                 auth_config._LDAP_SERVER,
-                f"`{auth_config._LDAP_SERVER}` attribute must be populated when {auth_config._PROTOCOL_LDAP} is used."
+                f"`{auth_config._LDAP_SERVER}` attribute must be populated when {auth_config._PROTOCOL_LDAP} is used.",
             )
         if auth_config._LDAP_BASE_DN not in auth_config.properties:
             self._error(
                 "properties",
                 auth_config._LDAP_BASE_DN,
-                f"`{auth_config._LDAP_BASE_DN}` field must be populated when {auth_config._PROTOCOL_LDAP} is used."
+                f"`{auth_config._LDAP_BASE_DN}` field must be populated when {auth_config._PROTOCOL_LDAP} is used.",
             )
-

--- a/src/taipy/config/checker/_checkers/_config_checker.py
+++ b/src/taipy/config/checker/_checkers/_config_checker.py
@@ -48,7 +48,8 @@ class _ConfigChecker:
                 self._error(
                     config_key,
                     config_value,
-                    f"{config_key} field of {parent_config_class.__name__} {config_id} must be populated with a list of {child_config_class.__name__} objects.",
+                    f"{config_key} field of {parent_config_class.__name__} {config_id} must be populated with a list "
+                    f"of {child_config_class.__name__} objects.",
                 )
 
     def _check_existing_config_id(self, config):

--- a/src/taipy/config/common/_template_handler.py
+++ b/src/taipy/config/common/_template_handler.py
@@ -12,7 +12,7 @@
 import os
 import re
 from collections import UserDict
-from datetime import datetime
+from datetime import datetime, timedelta
 from importlib import import_module
 from operator import attrgetter
 from pydoc import locate
@@ -99,6 +99,26 @@ class _TemplateHandler:
             return datetime.fromisoformat(val)
         except ValueError:
             raise InconsistentEnvVariableError(f"{val} is not a valid datetime.")
+
+    @staticmethod
+    def _to_timedelta(val: str) -> timedelta:
+        """
+        Parse a time string e.g. (2h13m) into a timedelta object.
+
+        :param timedelta_str: A string identifying a duration.  (eg. 2h13m)
+        :return datetime.timedelta: A datetime.timedelta object
+        """
+        regex = re.compile(
+            r"^((?P<days>[\.\d]+?)d)? *"
+            r"((?P<hours>[\.\d]+?)h)? *"
+            r"((?P<minutes>[\.\d]+?)m)? *"
+            r"((?P<seconds>[\.\d]+?)s)?$"
+        )
+        parts = regex.match(val)
+        if not parts:
+            raise InconsistentEnvVariableError(f"{val} is not a valid timedelta.")
+        time_params = {name: float(param) for name, param in parts.groupdict().items() if param}
+        return timedelta(**time_params)  # type: ignore
 
     @staticmethod
     def _to_scope(val: str) -> Scope:

--- a/src/taipy/config/config.pyi
+++ b/src/taipy/config/config.pyi
@@ -27,7 +27,6 @@ from taipy.core.config import (
     TaskConfig,
     PipelineConfig,
     ScenarioConfig,
-    Frequency,
 )
 
 class Config:

--- a/src/taipy/config/unique_section.py
+++ b/src/taipy/config/unique_section.py
@@ -1,15 +1,25 @@
+# Copyright 2022 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 from abc import ABC
 
-from .section import Section
 from .common._validate_id import _validate_id
+from .section import Section
 
 
 class UniqueSection(Section, ABC):
-    """ A UniqueSection is a configuration `Section^` that can have only one instance.
+    """A UniqueSection is a configuration `Section^` that can have only one instance.
 
     A UniqueSection is only defined by the section name.
     """
 
     def __init__(self, **properties):
         super().__init__(_validate_id(self.name), **properties)
-

--- a/tests/config/test_section_serialization.py
+++ b/tests/config/test_section_serialization.py
@@ -65,7 +65,7 @@ attribute = "my_attribute"
 prop = "my_prop"
 prop_int = "1:int"
 prop_bool = "False:bool"
-prop_list = [ "p1", "1991-01-01T00:00:00:datetime",]
+prop_list = [ "p1", "1991-01-01T00:00:00:datetime", "1d0h0m0s:timedelta",]
 prop_scope = "SCENARIO:SCOPE"
 prop_freq = "QUARTERLY:FREQUENCY"
 baz = "ENV[QUX]"
@@ -95,7 +95,7 @@ baz = "ENV[QUX]"
             prop="my_prop",
             prop_int=1,
             prop_bool=False,
-            prop_list=["p1", datetime.datetime(1991, 1, 1)],
+            prop_list=["p1", datetime.datetime(1991, 1, 1), datetime.timedelta(days=1)],
             prop_scope=Scope.SCENARIO,
             prop_freq=Frequency.QUARTERLY,
             baz="ENV[QUX]",
@@ -130,7 +130,7 @@ attribute = "my_attribute"
 prop = "my_prop"
 prop_int = "1:int"
 prop_bool = "False:bool"
-prop_list = [ "p1", "1991-01-01T00:00:00:datetime",]
+prop_list = [ "p1", "1991-01-01T00:00:00:datetime", "1d0h0m0s:timedelta",]
 prop_scope = "SCENARIO:SCOPE"
 prop_freq = "QUARTERLY:FREQUENCY"
 baz = "ENV[QUX]"
@@ -168,7 +168,11 @@ baz = "ENV[QUX]"
         assert Config.unique_sections[UniqueSectionForTest.name].prop == "my_prop"
         assert Config.unique_sections[UniqueSectionForTest.name].prop_int == 1
         assert Config.unique_sections[UniqueSectionForTest.name].prop_bool is False
-        assert Config.unique_sections[UniqueSectionForTest.name].prop_list == ["p1", datetime.datetime(1991, 1, 1)]
+        assert Config.unique_sections[UniqueSectionForTest.name].prop_list == [
+            "p1",
+            datetime.datetime(1991, 1, 1),
+            datetime.timedelta(days=1),
+        ]
         assert Config.unique_sections[UniqueSectionForTest.name].prop_scope == Scope.SCENARIO
         assert Config.unique_sections[UniqueSectionForTest.name].prop_freq == Frequency.QUARTERLY
         assert Config.unique_sections[UniqueSectionForTest.name].baz == "qux"

--- a/tests/config/test_section_serialization.py
+++ b/tests/config/test_section_serialization.py
@@ -295,7 +295,8 @@ def test_write_json_configuration_file():
 "prop_bool": "False:bool",
 "prop_list": [
 "p1",
-"1991-01-01T00:00:00:datetime"
+"1991-01-01T00:00:00:datetime",
+"1d0h0m0s:timedelta"
 ],
 "prop_scope": "SCENARIO:SCOPE",
 "prop_freq": "QUARTERLY:FREQUENCY"
@@ -328,7 +329,7 @@ def test_write_json_configuration_file():
         prop="my_prop",
         prop_int=1,
         prop_bool=False,
-        prop_list=["p1", datetime.datetime(1991, 1, 1)],
+        prop_list=["p1", datetime.datetime(1991, 1, 1), datetime.timedelta(days=1)],
         prop_scope=Scope.SCENARIO,
         prop_freq=Frequency.QUARTERLY,
     )
@@ -362,7 +363,8 @@ def test_read_json_configuration_file():
 "prop_bool": "False:bool",
 "prop_list": [
 "p1",
-"1991-01-01T00:00:00:datetime"
+"1991-01-01T00:00:00:datetime",
+"1d0h0m0s:timedelta"
 ],
 "prop_scope": "SCENARIO:SCOPE",
 "prop_freq": "QUARTERLY:FREQUENCY"
@@ -396,7 +398,11 @@ def test_read_json_configuration_file():
     assert Config.unique_sections[UniqueSectionForTest.name].prop == "my_prop"
     assert Config.unique_sections[UniqueSectionForTest.name].prop_int == 1
     assert Config.unique_sections[UniqueSectionForTest.name].prop_bool is False
-    assert Config.unique_sections[UniqueSectionForTest.name].prop_list == ["p1", datetime.datetime(1991, 1, 1)]
+    assert Config.unique_sections[UniqueSectionForTest.name].prop_list == [
+        "p1",
+        datetime.datetime(1991, 1, 1),
+        datetime.timedelta(days=1),
+    ]
     assert Config.unique_sections[UniqueSectionForTest.name].prop_scope == Scope.SCENARIO
     assert Config.unique_sections[UniqueSectionForTest.name].prop_freq == Frequency.QUARTERLY
 


### PR DESCRIPTION
Had to also add support here on config to the [issue](https://app.zenhub.com/workspaces/taipy-613ef328affde6000ff77fb3/issues/gh/avaiga/taipy-core/425)`. Because the error would occur when trying to serialize a config.

This is a similar implementation to what we did on [core 425](https://github.com/Avaiga/taipy-core/pull/437). Here we don't need the decoder because this is handled by the `_TemplateHandler` class. We can't import the common code from taipy-core to avoid circular imports, but it is recommended that we isolate this Enconder/Decoders in only one place to avoid mismatch of functionality between config and core.