### PR TITLE
Fix/Core#588 - No error message on ConfigurationUpdateBlocked

### DIFF
--- a/src/taipy/config/common/_config_blocker.py
+++ b/src/taipy/config/common/_config_blocker.py
@@ -36,11 +36,11 @@ class _ConfigBlocker:
             def _check_if_is_blocking(*args, **kwargs):
                 if cls.__block_config_update:
                     error_message = (
-                        "ConfigurationUpdateBlocked: config service should be stopped by running core.stop() before"
-                        " modifying it. For more information, please refer to:"
+                        "The Core service should be stopped by running core.stop() before"
+                        " modifying the Configuration. For more information, please refer to:"
                         " https://docs.taipy.io/en/latest/manuals/running_services/#running-core."
                     )
-                    cls.__logger.error(error_message)
+                    cls.__logger.error("ConfigurationUpdateBlocked: " + error_message)
                     raise ConfigurationUpdateBlocked(error_message)
 
                 return f(*args, **kwargs)

--- a/src/taipy/config/common/_config_blocker.py
+++ b/src/taipy/config/common/_config_blocker.py
@@ -11,12 +11,14 @@
 
 import functools
 
+from ...logger._taipy_logger import _TaipyLogger
 from ..exceptions.exceptions import ConfigurationUpdateBlocked
 
 
 class _ConfigBlocker:
     """Configuration blocker singleton."""
 
+    __logger = _TaipyLogger._get_logger()
     __block_config_update = False
 
     @classmethod
@@ -33,7 +35,13 @@ class _ConfigBlocker:
             @functools.wraps(f)
             def _check_if_is_blocking(*args, **kwargs):
                 if cls.__block_config_update:
-                    raise ConfigurationUpdateBlocked()
+                    error_message = (
+                        "ConfigurationUpdateBlocked: config service should be stopped by running core.stop() before"
+                        " modifying it. For more information, please refer to:"
+                        " https://docs.taipy.io/en/latest/manuals/running_services/#running-core."
+                    )
+                    cls.__logger.error(error_message)
+                    raise ConfigurationUpdateBlocked(error_message)
 
                 return f(*args, **kwargs)
 

--- a/src/taipy/config/config.pyi
+++ b/src/taipy/config/config.pyi
@@ -172,6 +172,9 @@ class Config:
     def scenarios(cls) -> Dict[str, ScenarioConfig]:
         """"""
 
+    def core(cls) -> Dict[str, CoreSection]:
+        """"""
+
     @staticmethod
     def configure_scenario(
         id: str,


### PR DESCRIPTION
https://github.com/Avaiga/taipy-core/issues/588

In this PR, when `ConfigurationUpdateBlocked` is raised, there will be an error message to help user know what is going on.

The log will be something like this (in both notebook and normal Python env).

<img width="1412" alt="image" src="https://github.com/Avaiga/taipy-config/assets/37588363/4808cc39-70ca-4035-b5da-d1e6f42e4d51">

