### PR TITLE
Default and python configs updated at compilation

### DIFF
--- a/src/taipy/config/_config.py
+++ b/src/taipy/config/_config.py
@@ -25,6 +25,14 @@ class _Config:
         self._unique_sections: Dict[str, UniqueSection] = {}
         self._global_config: GlobalAppConfig = GlobalAppConfig()
 
+    def clear(self):
+        self._global_config.clear()
+        for unique_section in self._unique_sections.values():
+            unique_section.clear()
+        for sections in self._sections.values():
+            for section in sections.values():
+                section.clear()
+
     @classmethod
     def _default_config(cls):
         config = _Config()
@@ -38,13 +46,13 @@ class _Config:
                 if section := self._unique_sections.get(section_name, None):
                     section._update(other_section._to_dict())
                 else:
-                    self._unique_sections[section_name] = other_config._unique_sections[section_name]
+                    self._unique_sections[section_name] = copy(other_config._unique_sections[section_name])
         if other_config._sections:
             for section_name, other_non_unique_sections in other_config._sections.items():
                 if non_unique_sections := self._sections.get(section_name, None):
                     self.__update_sections(non_unique_sections, other_non_unique_sections, None)
                 else:
-                    self._sections[section_name] = other_non_unique_sections
+                    self._sections[section_name] = {k: copy(v) for k, v in other_non_unique_sections.items()}
 
     def __update_sections(self, entity_config, other_entity_configs, _class):
         if self.DEFAULT_KEY in other_entity_configs:

--- a/src/taipy/config/_config.py
+++ b/src/taipy/config/_config.py
@@ -25,13 +25,13 @@ class _Config:
         self._unique_sections: Dict[str, UniqueSection] = {}
         self._global_config: GlobalAppConfig = GlobalAppConfig()
 
-    def clear(self):
-        self._global_config.clear()
+    def _clean(self):
+        self._global_config._clean()
         for unique_section in self._unique_sections.values():
-            unique_section.clear()
+            unique_section._clean()
         for sections in self._sections.values():
             for section in sections.values():
-                section.clear()
+                section._clean()
 
     @classmethod
     def _default_config(cls):

--- a/src/taipy/config/config.py
+++ b/src/taipy/config/config.py
@@ -226,7 +226,7 @@ class Config:
     @classmethod
     def __compile_configs(cls):
         Config._override_env_file()
-        cls._applied_config.clear()
+        cls._applied_config._clean()
         if cls._default_config:
             cls._applied_config._update(cls._default_config)
         if cls._python_config:

--- a/src/taipy/config/config.py
+++ b/src/taipy/config/config.py
@@ -33,9 +33,9 @@ class Config:
     __logger = _TaipyLogger._get_logger()
     _default_config = _Config._default_config()
     _python_config = _Config()
-    _file_config = None
-    _env_file_config = None
-    _applied_config = _Config._default_config()
+    _file_config = _Config()
+    _env_file_config = _Config()
+    _applied_config = _Config()
     _collector = IssueCollector()
     _serializer = _TomlSerializer()
     __json_serializer = _JsonSerializer()
@@ -226,7 +226,7 @@ class Config:
     @classmethod
     def __compile_configs(cls):
         Config._override_env_file()
-        cls._applied_config = _Config._default_config()
+        cls._applied_config.clear()
         if cls._default_config:
             cls._applied_config._update(cls._default_config)
         if cls._python_config:

--- a/src/taipy/config/global_app/global_app_config.py
+++ b/src/taipy/config/global_app/global_app_config.py
@@ -135,6 +135,13 @@ class GlobalAppConfig:
         config._repository_properties = cls._DEFAULT_REPOSITORY_PROPERTIES.copy()
         return config
 
+    def clear(self):
+        self._root_folder = self._DEFAULT_ROOT_FOLDER
+        self._storage_folder = self._DEFAULT_STORAGE_FOLDER
+        self._clean_entities_enabled = self._CLEAN_ENTITIES_ENABLED_TEMPLATE
+        self._repository_type = self._DEFAULT_REPOSITORY_TYPE
+        self._repository_properties = self._DEFAULT_REPOSITORY_PROPERTIES.copy()
+
     def _to_dict(self):
         as_dict = {}
         if self._root_folder:

--- a/src/taipy/config/global_app/global_app_config.py
+++ b/src/taipy/config/global_app/global_app_config.py
@@ -135,7 +135,7 @@ class GlobalAppConfig:
         config._repository_properties = cls._DEFAULT_REPOSITORY_PROPERTIES.copy()
         return config
 
-    def clear(self):
+    def _clean(self):
         self._root_folder = self._DEFAULT_ROOT_FOLDER
         self._storage_folder = self._DEFAULT_STORAGE_FOLDER
         self._clean_entities_enabled = self._CLEAN_ENTITIES_ENABLED_TEMPLATE

--- a/src/taipy/config/section.py
+++ b/src/taipy/config/section.py
@@ -40,6 +40,10 @@ class Section:
         raise NotImplementedError
 
     @abstractmethod
+    def clear(self):
+        raise NotImplementedError
+
+    @abstractmethod
     def _to_dict(self):
         raise NotImplementedError
 

--- a/src/taipy/config/section.py
+++ b/src/taipy/config/section.py
@@ -40,7 +40,7 @@ class Section:
         raise NotImplementedError
 
     @abstractmethod
-    def clear(self):
+    def _clean(self):
         raise NotImplementedError
 
     @abstractmethod

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -31,9 +31,9 @@ def reset_configuration_singleton():
     Config.unblock_update()
     Config._default_config = _Config()._default_config()
     Config._python_config = _Config()
-    Config._file_config = None
-    Config._env_file_config = None
-    Config._applied_config = _Config._default_config()
+    Config._file_config = _Config()
+    Config._env_file_config = _Config()
+    Config._applied_config = _Config()
     Config._collector = IssueCollector()
     Config._serializer = _TomlSerializer()
     Config._comparator = _ConfigComparator()

--- a/tests/config/test_compilation.py
+++ b/tests/config/test_compilation.py
@@ -1,0 +1,56 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import pytest
+from src.taipy.config.config import Config
+
+
+def test_applied_config_compilation_does_not_change_other_configs():
+    assert len(Config._default_config._unique_sections) == 1
+    assert Config._default_config._unique_sections["unique_section_name"] is not None
+    assert Config._default_config._unique_sections["unique_section_name"].attribute == "default_attribute"
+    assert Config._default_config._unique_sections["unique_section_name"].prop is None
+    assert len(Config._python_config._unique_sections) == 0
+    assert len(Config._file_config._unique_sections) == 0
+    assert len(Config._env_file_config._unique_sections) == 0
+    assert len(Config._applied_config._unique_sections) == 1
+    assert Config._applied_config._unique_sections["unique_section_name"] is not None
+    assert Config._applied_config._unique_sections["unique_section_name"].attribute == "default_attribute"
+    assert Config._applied_config._unique_sections["unique_section_name"].prop is None
+    assert len(Config.unique_sections) == 1
+    assert Config.unique_sections["unique_section_name"] is not None
+    assert Config.unique_sections["unique_section_name"].attribute == "default_attribute"
+    assert Config.unique_sections["unique_section_name"].prop is None
+    assert Config._applied_config._unique_sections["unique_section_name"] is not Config._default_config._unique_sections["unique_section_name"]
+
+    Config.configure_unique_section_for_tests("qwe", prop="rty")
+
+    assert len(Config._default_config._unique_sections) == 1
+    assert Config._default_config._unique_sections["unique_section_name"] is not None
+    assert Config._default_config._unique_sections["unique_section_name"].attribute == "default_attribute"
+    assert Config._default_config._unique_sections["unique_section_name"].prop is None
+    assert len(Config._python_config._unique_sections) == 1
+    assert Config._python_config._unique_sections["unique_section_name"] is not None
+    assert Config._python_config._unique_sections["unique_section_name"].attribute == "qwe"
+    assert Config._python_config._unique_sections["unique_section_name"].prop == "rty"
+    assert Config._python_config._unique_sections["unique_section_name"] != Config._default_config._unique_sections["unique_section_name"]
+    assert len(Config._file_config._unique_sections) == 0
+    assert len(Config._env_file_config._unique_sections) == 0
+    assert len(Config._applied_config._unique_sections) == 1
+    assert Config._applied_config._unique_sections["unique_section_name"] is not None
+    assert Config._applied_config._unique_sections["unique_section_name"].attribute == "qwe"
+    assert Config._applied_config._unique_sections["unique_section_name"].prop == "rty"
+    assert Config._python_config._unique_sections["unique_section_name"] != Config._applied_config._unique_sections["unique_section_name"]
+    assert Config._default_config._unique_sections["unique_section_name"] != Config._applied_config._unique_sections["unique_section_name"]
+    assert len(Config.unique_sections) == 1
+    assert Config.unique_sections["unique_section_name"] is not None
+    assert Config.unique_sections["unique_section_name"].attribute == "qwe"
+    assert Config.unique_sections["unique_section_name"].prop == "rty"

--- a/tests/config/test_section_registration.py
+++ b/tests/config/test_section_registration.py
@@ -166,4 +166,4 @@ def test_block_registration():
 
     # mySection stay the same
     assert mySection.attribute == "my_attribute"
-    assert mySection.properties == {"prop": "my_prop", "foo": "bar"}
+    assert mySection.properties == {"prop": "my_prop", "foo": "bar", "prop_int": 0}

--- a/tests/config/test_section_serialization.py
+++ b/tests/config/test_section_serialization.py
@@ -79,6 +79,7 @@ prop_int = "0:int"
 
 [section_name.my_id]
 attribute = "my_attribute"
+prop = "default_prop"
 prop_int = "1:int"
 prop_bool = "False:bool"
 prop_list = [ "unique_section_name:SECTION",]
@@ -147,6 +148,7 @@ prop_int = "0:int"
 
 [section_name.my_id]
 attribute = "my_attribute"
+prop = "default_prop"
 prop_int = "1:int"
 prop_bool = "False:bool"
 prop_list = [ "unique_section_name", "section_name.my_id",]
@@ -194,7 +196,7 @@ baz = "ENV[QUX]"
         assert Config.sections[SectionForTest.name]["default"].prop_int == 0
         assert Config.sections[SectionForTest.name]["my_id"] is not None
         assert Config.sections[SectionForTest.name]["my_id"].attribute == "my_attribute"
-        assert Config.sections[SectionForTest.name]["my_id"].prop is None
+        assert Config.sections[SectionForTest.name]["my_id"].prop == "default_prop"
         assert Config.sections[SectionForTest.name]["my_id"].prop_int == 1
         assert Config.sections[SectionForTest.name]["my_id"].prop_bool is False
         assert Config.sections[SectionForTest.name]["my_id"].prop_list == ["unique_section_name", "section_name.my_id"]
@@ -243,11 +245,15 @@ prop_int = "0:int"
 
 [section_name.my_id]
 attribute = "my_attribute"
+prop = "default_prop"
+prop_int = "0:int"
 prop_fct_list = [ "tests.config.test_section_serialization.add:function",]
 prop_class_list = [ "tests.config.test_section_serialization.CustomClass:class",]
 
 [section_name.my_id_2]
 attribute = "my_attribute_2"
+prop = "default_prop"
+prop_int = "0:int"
 prop_fct_list = [ "builtins.print:function", "builtins.pow:function",]
     """.strip()
 
@@ -313,6 +319,7 @@ def test_write_json_configuration_file():
 },
 "my_id": {
 "attribute": "my_attribute",
+"prop": "default_prop",
 "prop_int": "1:int",
 "prop_bool": "False:bool",
 "prop_list": [
@@ -381,6 +388,7 @@ def test_read_json_configuration_file():
 },
 "my_id": {
 "attribute": "my_attribute",
+"prop": "default_prop",
 "prop_int": "1:int",
 "prop_bool": "False:bool",
 "prop_list": [
@@ -420,7 +428,7 @@ def test_read_json_configuration_file():
     assert Config.sections[SectionForTest.name]["default"].prop_int == 0
     assert Config.sections[SectionForTest.name]["my_id"] is not None
     assert Config.sections[SectionForTest.name]["my_id"].attribute == "my_attribute"
-    assert Config.sections[SectionForTest.name]["my_id"].prop is None
+    assert Config.sections[SectionForTest.name]["my_id"].prop == "default_prop"
     assert Config.sections[SectionForTest.name]["my_id"].prop_int == 1
     assert Config.sections[SectionForTest.name]["my_id"].prop_bool is False
     assert Config.sections[SectionForTest.name]["my_id"].prop_list == ["unique_section_name"]
@@ -456,6 +464,8 @@ def test_read_write_json_configuration_file_with_function_and_class():
 },
 "my_id": {
 "attribute": "my_attribute",
+"prop": "default_prop",
+"prop_int": "0:int",
 "prop_fct_list": [
 "tests.config.test_section_serialization.add:function"
 ],
@@ -465,6 +475,8 @@ def test_read_write_json_configuration_file_with_function_and_class():
 },
 "my_id_2": {
 "attribute": "my_attribute_2",
+"prop": "default_prop",
+"prop_int": "0:int",
 "prop_fct_list": [
 "builtins.print:function",
 "builtins.pow:function"

--- a/tests/config/utils/section_for_tests.py
+++ b/tests/config/utils/section_for_tests.py
@@ -38,7 +38,7 @@ class SectionForTest(Section):
     def attribute(self, val):
         self._attribute = val
 
-    def clear(self):
+    def _clean(self):
         self._attribute = None
         self._properties.clear()
 

--- a/tests/config/utils/section_for_tests.py
+++ b/tests/config/utils/section_for_tests.py
@@ -27,7 +27,7 @@ class SectionForTest(Section):
         super().__init__(id, **properties)
 
     def __copy__(self):
-        return SectionForTest(self._attribute, **copy(self._properties))
+        return SectionForTest(self.id, self._attribute, **copy(self._properties))
 
     @property
     def attribute(self):
@@ -37,6 +37,10 @@ class SectionForTest(Section):
     @_ConfigBlocker._check()
     def attribute(self, val):
         self._attribute = val
+
+    def clear(self):
+        self._attribute = None
+        self._properties.clear()
 
     def _to_dict(self):
         as_dict = {}
@@ -53,7 +57,11 @@ class SectionForTest(Section):
 
     def _update(self, as_dict: Dict[str, Any], default_section=None):
         self._attribute = as_dict.pop(self._MY_ATTRIBUTE_KEY, self._attribute)
+        if self._attribute is None and default_section:
+            self._attribute = default_section._attribute
         self._properties.update(as_dict)
+        if default_section:
+            self._properties = {**default_section.properties, **self._properties}
 
     @staticmethod
     def _configure(id: str, attribute: str, **properties):

--- a/tests/config/utils/unique_section_for_tests.py
+++ b/tests/config/utils/unique_section_for_tests.py
@@ -39,6 +39,10 @@ class UniqueSectionForTest(UniqueSection):
     def attribute(self, val):
         self._attribute = val
 
+    def clear(self):
+        self._attribute = None
+        self._properties.clear()
+
     def _to_dict(self):
         as_dict = {}
         if self._attribute is not None:
@@ -54,7 +58,11 @@ class UniqueSectionForTest(UniqueSection):
 
     def _update(self, as_dict: Dict[str, Any], default_section=None):
         self._attribute = as_dict.pop(self._MY_ATTRIBUTE_KEY, self._attribute)
+        if self._attribute is None and default_section:
+            self._attribute = default_section._attribute
         self._properties.update(as_dict)
+        if default_section:
+            self._properties = {**default_section.properties, **self._properties}
 
     @staticmethod
     def _configure(attribute: str, **properties):

--- a/tests/config/utils/unique_section_for_tests.py
+++ b/tests/config/utils/unique_section_for_tests.py
@@ -39,7 +39,7 @@ class UniqueSectionForTest(UniqueSection):
     def attribute(self, val):
         self._attribute = val
 
-    def clear(self):
+    def _clean(self):
         self._attribute = None
         self._properties.clear()
 


### PR DESCRIPTION
Fix issue: https://github.com/Avaiga/taipy-config/issues/69

- Make the _applied_config and the _default_config two different instances.
- Copy sections instead of re-using the same instance in the _Config._update method
- make the _config initializations consistent
- Create clear methods to clear the _applied_config before compilation.
- Unit tests

Note the Section Class changed. A new abstract method must be implemented. The fix must be propagated to taipy-core