### PR TITLE
Fix/Core#636 - Nested section of _Config should point to its sections

### DIFF
--- a/src/taipy/config/_config.py
+++ b/src/taipy/config/_config.py
@@ -75,20 +75,21 @@ class _Config:
                     entity_config[cfg_id]._update(sub_config._to_dict(), entity_config.get(self.DEFAULT_KEY))
             self.__point_nested_section_to_self(sub_config)
 
-    def __point_nested_section_to_self(self, sub_config):
+    def __point_nested_section_to_self(self, section):
         """Loop through attributes of a Section to find if any attribute has a list of Section as value.
         If there is, update each nested Section by the corresponding instance in self.
 
         Args:
-            sub_config (Section): The Section to search for nested sections.
+            section (Section): The Section to search for nested sections.
         """
-        for _, attr_value in vars(sub_config).items():
+        for _, attr_value in vars(section).items():
+            # ! This will fail if an attribute is a dictionary, or nested list of Sections.
             if not isinstance(attr_value, list):
-                return
+                continue
 
             for index, item in enumerate(attr_value):
                 if not isinstance(item, Section):
-                    return
+                    continue
 
                 if sub_item := self._sections.get(item.name, {}).get(item.id, None):
                     attr_value[index] = sub_item

--- a/src/taipy/config/_config.py
+++ b/src/taipy/config/_config.py
@@ -76,10 +76,19 @@ class _Config:
             self.__point_nested_section_to_self(sub_config)
 
     def __point_nested_section_to_self(self, sub_config):
+        """Loop through attributes of a Section to find if any attribute has a list of Section as value.
+        If there is, update each nested Section by the corresponding instance in self.
+
+        Args:
+            sub_config (Section): The Section to search for nested sections.
+        """
         for _, attr_value in vars(sub_config).items():
-            if isinstance(attr_value, list):
-                for index, item in enumerate(attr_value):
-                    if isinstance(item, Section):
-                        if sub_sections := self._sections.get(item.name, None):
-                            if sub_item := sub_sections.get(item.id):
-                                attr_value[index] = sub_item
+            if not isinstance(attr_value, list):
+                return
+
+            for index, item in enumerate(attr_value):
+                if not isinstance(item, Section):
+                    return
+
+                if sub_item := self._sections.get(item.name, {}).get(item.id, None):
+                    attr_value[index] = sub_item

--- a/src/taipy/config/config.pyi
+++ b/src/taipy/config/config.pyi
@@ -190,6 +190,11 @@ class Config:
 
     @classmethod
     @property
+    def migration_functions(cls) -> Dict[str, MigrationConfig]:
+        """"""
+
+    @classmethod
+    @property
     def core(cls) -> Dict[str, CoreSection]:
         """"""
 

--- a/tests/config/test_compilation.py
+++ b/tests/config/test_compilation.py
@@ -13,16 +13,16 @@ import pytest
 
 from src.taipy.config.config import Config
 from src.taipy.config.section import Section
-from tests.config.utils.list_section_for_tests import ListSectionForTest
 from tests.config.utils.named_temporary_file import NamedTemporaryFile
 from tests.config.utils.section_for_tests import SectionForTest
+from tests.config.utils.section_of_sections_list_for_tests import SectionOfSectionsListForTest
 
 
 @pytest.fixture
 def _init_list_section_for_test():
-    Config._register_default(ListSectionForTest(Section._DEFAULT_KEY, [], prop="default_prop", prop_int=0))
-    Config.configure_list_section_for_tests = ListSectionForTest._configure
-    Config.list_section_name = Config.sections[ListSectionForTest.name]
+    Config._register_default(SectionOfSectionsListForTest(Section._DEFAULT_KEY, [], prop="default_prop", prop_int=0))
+    Config.configure_list_section_for_tests = SectionOfSectionsListForTest._configure
+    Config.list_section_name = Config.sections[SectionOfSectionsListForTest.name]
 
 
 def test_applied_config_compilation_does_not_change_other_configs():
@@ -83,7 +83,7 @@ def test_applied_config_compilation_does_not_change_other_configs():
 def test_nested_section_instance_in_python(_init_list_section_for_test):
     s1_cfg = Config.configure_section_for_tests("s1", attribute="foo")
     s2_cfg = Config.configure_section_for_tests("s2", attribute="bar")
-    ss_cfg = Config.configure_list_section_for_tests("ss", attribute=[s1_cfg, s2_cfg])
+    ss_cfg = Config.configure_list_section_for_tests("ss", attribute="foo", sections_list=[s1_cfg, s2_cfg])
 
     s1_config_applied_instance = Config.section_name["s1"]
     s1_config_python_instance = Config._python_config._sections[SectionForTest.name]["s1"]
@@ -91,13 +91,13 @@ def test_nested_section_instance_in_python(_init_list_section_for_test):
     s2_config_applied_instance = Config.section_name["s2"]
     s2_config_python_instance = Config._python_config._sections[SectionForTest.name]["s2"]
 
-    assert ss_cfg.attribute[0] is s1_config_applied_instance
-    assert ss_cfg.attribute[0] is not s1_config_python_instance
-    assert ss_cfg.attribute[1] is s2_config_applied_instance
-    assert ss_cfg.attribute[1] is not s2_config_python_instance
+    assert ss_cfg.sections_list[0] is s1_config_applied_instance
+    assert ss_cfg.sections_list[0] is not s1_config_python_instance
+    assert ss_cfg.sections_list[1] is s2_config_applied_instance
+    assert ss_cfg.sections_list[1] is not s2_config_python_instance
 
 
-def _configure_scenario_in_toml():
+def _configure_in_toml():
     return NamedTemporaryFile(
         content="""
 [TAIPY]
@@ -109,13 +109,13 @@ attribute = "foo"
 attribute = "bar"
 
 [list_section_name.ss]
-sections_list = [ "s1:SECTION", "s2:SECTION"]
+sections_list = [ "foo", "s1:SECTION", "s2:SECTION"]
     """
     )
 
 
 def test_nested_section_instance_load_toml(_init_list_section_for_test):
-    toml_config = _configure_scenario_in_toml()
+    toml_config = _configure_in_toml()
     Config.load(toml_config)
 
     s1_config_applied_instance = Config.section_name["s1"]
@@ -126,14 +126,15 @@ def test_nested_section_instance_load_toml(_init_list_section_for_test):
 
     ss_cfg = Config.list_section_name["ss"]
 
-    assert ss_cfg.sections_list[0] is s1_config_applied_instance
-    assert ss_cfg.sections_list[0] is not s1_config_python_instance
-    assert ss_cfg.sections_list[1] is s2_config_applied_instance
-    assert ss_cfg.sections_list[1] is not s2_config_python_instance
+    assert ss_cfg.sections_list[0] == "foo"
+    assert ss_cfg.sections_list[1] is s1_config_applied_instance
+    assert ss_cfg.sections_list[1] is not s1_config_python_instance
+    assert ss_cfg.sections_list[2] is s2_config_applied_instance
+    assert ss_cfg.sections_list[2] is not s2_config_python_instance
 
 
 def test_nested_section_instance_override_toml(_init_list_section_for_test):
-    toml_config = _configure_scenario_in_toml()
+    toml_config = _configure_in_toml()
     Config.override(toml_config)
 
     s1_config_applied_instance = Config.section_name["s1"]
@@ -144,7 +145,8 @@ def test_nested_section_instance_override_toml(_init_list_section_for_test):
 
     ss_cfg = Config.list_section_name["ss"]
 
-    assert ss_cfg.sections_list[0] is s1_config_applied_instance
-    assert ss_cfg.sections_list[0] is not s1_config_python_instance
-    assert ss_cfg.sections_list[1] is s2_config_applied_instance
+    assert ss_cfg.sections_list[0] == "foo"
+    assert ss_cfg.sections_list[1] is s1_config_applied_instance
+    assert ss_cfg.sections_list[1] is not s1_config_python_instance
+    assert ss_cfg.sections_list[2] is s2_config_applied_instance
     assert ss_cfg.sections_list[1] is not s2_config_python_instance

--- a/tests/config/test_compilation.py
+++ b/tests/config/test_compilation.py
@@ -10,7 +10,19 @@
 # specific language governing permissions and limitations under the License.
 
 import pytest
+
 from src.taipy.config.config import Config
+from src.taipy.config.section import Section
+from tests.config.utils.list_section_for_tests import ListSectionForTest
+from tests.config.utils.named_temporary_file import NamedTemporaryFile
+from tests.config.utils.section_for_tests import SectionForTest
+
+
+@pytest.fixture
+def _init_list_section_for_test():
+    Config._register_default(ListSectionForTest(Section._DEFAULT_KEY, [], prop="default_prop", prop_int=0))
+    Config.configure_list_section_for_tests = ListSectionForTest._configure
+    Config.list_section_name = Config.sections[ListSectionForTest.name]
 
 
 def test_applied_config_compilation_does_not_change_other_configs():
@@ -29,7 +41,10 @@ def test_applied_config_compilation_does_not_change_other_configs():
     assert Config.unique_sections["unique_section_name"] is not None
     assert Config.unique_sections["unique_section_name"].attribute == "default_attribute"
     assert Config.unique_sections["unique_section_name"].prop is None
-    assert Config._applied_config._unique_sections["unique_section_name"] is not Config._default_config._unique_sections["unique_section_name"]
+    assert (
+        Config._applied_config._unique_sections["unique_section_name"]
+        is not Config._default_config._unique_sections["unique_section_name"]
+    )
 
     Config.configure_unique_section_for_tests("qwe", prop="rty")
 
@@ -41,16 +56,95 @@ def test_applied_config_compilation_does_not_change_other_configs():
     assert Config._python_config._unique_sections["unique_section_name"] is not None
     assert Config._python_config._unique_sections["unique_section_name"].attribute == "qwe"
     assert Config._python_config._unique_sections["unique_section_name"].prop == "rty"
-    assert Config._python_config._unique_sections["unique_section_name"] != Config._default_config._unique_sections["unique_section_name"]
+    assert (
+        Config._python_config._unique_sections["unique_section_name"]
+        != Config._default_config._unique_sections["unique_section_name"]
+    )
     assert len(Config._file_config._unique_sections) == 0
     assert len(Config._env_file_config._unique_sections) == 0
     assert len(Config._applied_config._unique_sections) == 1
     assert Config._applied_config._unique_sections["unique_section_name"] is not None
     assert Config._applied_config._unique_sections["unique_section_name"].attribute == "qwe"
     assert Config._applied_config._unique_sections["unique_section_name"].prop == "rty"
-    assert Config._python_config._unique_sections["unique_section_name"] != Config._applied_config._unique_sections["unique_section_name"]
-    assert Config._default_config._unique_sections["unique_section_name"] != Config._applied_config._unique_sections["unique_section_name"]
+    assert (
+        Config._python_config._unique_sections["unique_section_name"]
+        != Config._applied_config._unique_sections["unique_section_name"]
+    )
+    assert (
+        Config._default_config._unique_sections["unique_section_name"]
+        != Config._applied_config._unique_sections["unique_section_name"]
+    )
     assert len(Config.unique_sections) == 1
     assert Config.unique_sections["unique_section_name"] is not None
     assert Config.unique_sections["unique_section_name"].attribute == "qwe"
     assert Config.unique_sections["unique_section_name"].prop == "rty"
+
+
+def test_nested_section_instance_in_python(_init_list_section_for_test):
+    s1_cfg = Config.configure_section_for_tests("s1", attribute="foo")
+    s2_cfg = Config.configure_section_for_tests("s2", attribute="bar")
+    ss_cfg = Config.configure_list_section_for_tests("ss", attribute=[s1_cfg, s2_cfg])
+
+    s1_config_applied_instance = Config.section_name["s1"]
+    s1_config_python_instance = Config._python_config._sections[SectionForTest.name]["s1"]
+
+    s2_config_applied_instance = Config.section_name["s2"]
+    s2_config_python_instance = Config._python_config._sections[SectionForTest.name]["s2"]
+
+    assert ss_cfg.attribute[0] is s1_config_applied_instance
+    assert ss_cfg.attribute[0] is not s1_config_python_instance
+    assert ss_cfg.attribute[1] is s2_config_applied_instance
+    assert ss_cfg.attribute[1] is not s2_config_python_instance
+
+
+def _configure_scenario_in_toml():
+    return NamedTemporaryFile(
+        content="""
+[TAIPY]
+
+[section_name.s1]
+attribute = "foo"
+
+[section_name.s2]
+attribute = "bar"
+
+[list_section_name.ss]
+sections_list = [ "s1:SECTION", "s2:SECTION"]
+    """
+    )
+
+
+def test_nested_section_instance_load_toml(_init_list_section_for_test):
+    toml_config = _configure_scenario_in_toml()
+    Config.load(toml_config)
+
+    s1_config_applied_instance = Config.section_name["s1"]
+    s1_config_python_instance = Config._python_config._sections[SectionForTest.name]["s1"]
+
+    s2_config_applied_instance = Config.section_name["s2"]
+    s2_config_python_instance = Config._python_config._sections[SectionForTest.name]["s2"]
+
+    ss_cfg = Config.list_section_name["ss"]
+
+    assert ss_cfg.sections_list[0] is s1_config_applied_instance
+    assert ss_cfg.sections_list[0] is not s1_config_python_instance
+    assert ss_cfg.sections_list[1] is s2_config_applied_instance
+    assert ss_cfg.sections_list[1] is not s2_config_python_instance
+
+
+def test_nested_section_instance_override_toml(_init_list_section_for_test):
+    toml_config = _configure_scenario_in_toml()
+    Config.override(toml_config)
+
+    s1_config_applied_instance = Config.section_name["s1"]
+    s1_config_python_instance = Config._file_config._sections[SectionForTest.name]["s1"]
+
+    s2_config_applied_instance = Config.section_name["s2"]
+    s2_config_python_instance = Config._file_config._sections[SectionForTest.name]["s2"]
+
+    ss_cfg = Config.list_section_name["ss"]
+
+    assert ss_cfg.sections_list[0] is s1_config_applied_instance
+    assert ss_cfg.sections_list[0] is not s1_config_python_instance
+    assert ss_cfg.sections_list[1] is s2_config_applied_instance
+    assert ss_cfg.sections_list[1] is not s2_config_python_instance

--- a/tests/config/utils/list_section_for_tests.py
+++ b/tests/config/utils/list_section_for_tests.py
@@ -1,0 +1,77 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from copy import copy
+from typing import Any, Dict, List, Optional
+
+from src.taipy.config import Config, Section
+from src.taipy.config._config import _Config
+from src.taipy.config.common._config_blocker import _ConfigBlocker
+
+from .section_for_tests import SectionForTest
+
+
+class ListSectionForTest(Section):
+
+    name = "list_section_name"
+    _SECTIONS_LIST_KEY = "sections_list"
+
+    def __init__(self, id: str, sections_list: List = None, **properties):
+        self._sections_list = sections_list if sections_list else []
+        super().__init__(id, **properties)
+
+    def __copy__(self):
+        return ListSectionForTest(self.id, copy(self._sections_list), **copy(self._properties))
+
+    @property
+    def sections_list(self):
+        return list(self._sections_list)
+
+    @sections_list.setter  # type: ignore
+    @_ConfigBlocker._check()
+    def sections_list(self, val):
+        self._sections_list = val
+
+    def _clean(self):
+        self._sections_list = []
+        self._properties.clear()
+
+    def _to_dict(self):
+        as_dict = {}
+        if self._sections_list:
+            as_dict[self._SECTIONS_LIST_KEY] = self._sections_list
+        as_dict.update(self._properties)
+        return as_dict
+
+    @classmethod
+    def _from_dict(cls, as_dict: Dict[str, Any], id: str, config: Optional[_Config] = None):
+        as_dict.pop(cls._ID_KEY, id)
+        section_configs = config._sections.get(SectionForTest.name, None) or []  # type: ignore
+        sections_list = []
+        if inputs_as_str := as_dict.pop(cls._SECTIONS_LIST_KEY, None):
+            sections_list = [
+                section_configs[section_id] for section_id in inputs_as_str if section_id in section_configs
+            ]
+        return ListSectionForTest(id=id, sections_list=sections_list, **as_dict)
+
+    def _update(self, as_dict: Dict[str, Any], default_section=None):
+        self._sections_list = as_dict.pop(self._SECTIONS_LIST_KEY, self._sections_list)
+        if self._sections_list is None and default_section:
+            self._sections_list = default_section._sections_list
+        self._properties.update(as_dict)
+        if default_section:
+            self._properties = {**default_section.properties, **self._properties}
+
+    @staticmethod
+    def _configure(id: str, sections_list: List = None, **properties):
+        section = ListSectionForTest(id, sections_list, **properties)
+        Config._register(section)
+        return Config.sections[ListSectionForTest.name][id]

--- a/tests/config/utils/section_of_sections_list_for_tests.py
+++ b/tests/config/utils/section_of_sections_list_for_tests.py
@@ -19,17 +19,30 @@ from src.taipy.config.common._config_blocker import _ConfigBlocker
 from .section_for_tests import SectionForTest
 
 
-class ListSectionForTest(Section):
+class SectionOfSectionsListForTest(Section):
 
     name = "list_section_name"
+    _MY_ATTRIBUTE_KEY = "attribute"
     _SECTIONS_LIST_KEY = "sections_list"
 
-    def __init__(self, id: str, sections_list: List = None, **properties):
+    def __init__(self, id: str, attribute: Any = None, sections_list: List = None, **properties):
+        self._attribute = attribute
         self._sections_list = sections_list if sections_list else []
         super().__init__(id, **properties)
 
     def __copy__(self):
-        return ListSectionForTest(self.id, copy(self._sections_list), **copy(self._properties))
+        return SectionOfSectionsListForTest(
+            self.id, self._attribute, copy(self._sections_list), **copy(self._properties)
+        )
+
+    @property
+    def attribute(self):
+        return self._replace_templates(self._attribute)
+
+    @attribute.setter  # type: ignore
+    @_ConfigBlocker._check()
+    def attribute(self, val):
+        self._attribute = val
 
     @property
     def sections_list(self):
@@ -41,11 +54,14 @@ class ListSectionForTest(Section):
         self._sections_list = val
 
     def _clean(self):
+        self._attribute = None
         self._sections_list = []
         self._properties.clear()
 
     def _to_dict(self):
         as_dict = {}
+        if self._attribute is not None:
+            as_dict[self._MY_ATTRIBUTE_KEY] = self._attribute
         if self._sections_list:
             as_dict[self._SECTIONS_LIST_KEY] = self._sections_list
         as_dict.update(self._properties)
@@ -54,15 +70,21 @@ class ListSectionForTest(Section):
     @classmethod
     def _from_dict(cls, as_dict: Dict[str, Any], id: str, config: Optional[_Config] = None):
         as_dict.pop(cls._ID_KEY, id)
+        attribute = as_dict.pop(cls._MY_ATTRIBUTE_KEY, None)
         section_configs = config._sections.get(SectionForTest.name, None) or []  # type: ignore
         sections_list = []
         if inputs_as_str := as_dict.pop(cls._SECTIONS_LIST_KEY, None):
-            sections_list = [
-                section_configs[section_id] for section_id in inputs_as_str if section_id in section_configs
-            ]
-        return ListSectionForTest(id=id, sections_list=sections_list, **as_dict)
+            for section_id in inputs_as_str:
+                if section_id in section_configs:
+                    sections_list.append(section_configs[section_id])
+                else:
+                    sections_list.append(section_id)
+        return SectionOfSectionsListForTest(id=id, attribute=attribute, sections_list=sections_list, **as_dict)
 
     def _update(self, as_dict: Dict[str, Any], default_section=None):
+        self._attribute = as_dict.pop(self._MY_ATTRIBUTE_KEY, self._attribute)
+        if self._attribute is None and default_section:
+            self._attribute = default_section._attribute
         self._sections_list = as_dict.pop(self._SECTIONS_LIST_KEY, self._sections_list)
         if self._sections_list is None and default_section:
             self._sections_list = default_section._sections_list
@@ -71,7 +93,7 @@ class ListSectionForTest(Section):
             self._properties = {**default_section.properties, **self._properties}
 
     @staticmethod
-    def _configure(id: str, sections_list: List = None, **properties):
-        section = ListSectionForTest(id, sections_list, **properties)
+    def _configure(id: str, attribute: str, sections_list: List = None, **properties):
+        section = SectionOfSectionsListForTest(id, attribute, sections_list, **properties)
         Config._register(section)
-        return Config.sections[ListSectionForTest.name][id]
+        return Config.sections[SectionOfSectionsListForTest.name][id]


### PR DESCRIPTION
https://github.com/Avaiga/taipy-core/issues/636

In this PR, when compiling the _applied_config:
- Each time a new section is added, `__point_nested_section_to_self()` is called.
- This method check for list of nested sections, then update each item of the list with the correct instance of `self`.