### PR TITLE
Fix/doc#392 - Typos in config comparator log message

### DIFF
--- a/src/taipy/config/_config_comparator/_config_comparator.py
+++ b/src/taipy/config/_config_comparator/_config_comparator.py
@@ -132,10 +132,10 @@ class _ConfigComparator:
         new_version_number: Optional[str] = None,
     ):
         old_config_str = (
-            f"version {old_version_number} Configuration" if old_version_number else "current Configuration"
+            f"configuration for version {old_version_number}" if old_version_number else "current configuration"
         )
         new_config_str = (
-            f"version {new_version_number} Configuration" if new_version_number else "current Configuration"
+            f"configuration for version {new_version_number}" if new_version_number else "current configuration"
         )
 
         if unconflicted_sections := comparator_result.get(_ComparatorResult.UNCONFLICTED_SECTION_KEY):
@@ -148,7 +148,7 @@ class _ConfigComparator:
         if conflicted_sections := comparator_result.get(_ComparatorResult.CONFLICTED_SECTION_KEY):
             conflicted_messages = self.__get_messages(conflicted_sections)
             self.__logger.error(
-                f"The {old_config_str} is conflicted with the {new_config_str}:\n\t" + "\n\t".join(conflicted_messages)
+                f"The {old_config_str} conflicts with the {new_config_str}:\n\t" + "\n\t".join(conflicted_messages)
             )
 
     def __get_messages(self, diff_sections):

--- a/src/taipy/config/config.py
+++ b/src/taipy/config/config.py
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 import os
-from typing import Dict, Union
+from typing import Dict
 
 from ..logger._taipy_logger import _TaipyLogger
 from ._config import _Config

--- a/tests/config/test_config_comparator.py
+++ b/tests/config/test_config_comparator.py
@@ -286,7 +286,7 @@ class TestConfigComparator:
             t in error_messages[0]
             for t in [
                 "INFO",
-                "There are non-conflicting changes between the current Configuration and the current Configuration:",
+                "There are non-conflicting changes between the current configuration and the current configuration:",
             ]
         )
         assert 'section_name "section_2" has attribute "attribute" modified: 2:int -> attribute_2' in error_messages[1]
@@ -295,7 +295,7 @@ class TestConfigComparator:
             t in error_messages[3]
             for t in [
                 "ERROR",
-                "The current Configuration is conflicted with the current Configuration:",
+                "The current configuration conflicts with the current configuration:",
             ]
         )
         assert 'unique_section_name "prop" was modified: unique_prop_1 -> unique_prop_1b' in error_messages[4]
@@ -310,14 +310,14 @@ class TestConfigComparator:
             t in error_messages[0]
             for t in [
                 "INFO",
-                "There are non-conflicting changes between the version 1.0 Configuration and the current Configuration:",
+                "There are non-conflicting changes between the configuration for version 1.0 and the current configuration:",
             ]
         )
         assert all(
             t in error_messages[3]
             for t in [
                 "ERROR",
-                "The version 1.0 Configuration is conflicted with the current Configuration:",
+                "The configuration for version 1.0 conflicts with the current configuration:",
             ]
         )
 


### PR DESCRIPTION
https://github.com/Avaiga/taipy-doc/issues/392

This PR fixes several issues noticed in https://github.com/Avaiga/taipy-doc/pull/499.